### PR TITLE
reproduce bug input clear bug

### DIFF
--- a/components/input/Input.tsx
+++ b/components/input/Input.tsx
@@ -87,6 +87,7 @@ export function resolveOnChange<E extends HTMLInputElement | HTMLTextAreaElement
     onChange(event as React.ChangeEvent<E>);
     // reset target ref value
     target.value = originalInputValue;
+    console.log(target.value);
     return;
   }
 

--- a/components/input/demo/basic.md
+++ b/components/input/demo/basic.md
@@ -14,7 +14,28 @@ title:
 Basic usage example.
 
 ```jsx
+import React, { useState } from 'react';
 import { Input } from 'antd';
 
-ReactDOM.render(<Input placeholder="Basic usage" />, mountNode);
+const MyComp = () => {
+  const [query, setQuery] = useState({ v1: '', v2: '' });
+
+  return (
+    <>
+      <Input
+        value={query.v2}
+        onChange={e => {
+          console.log({ change: e.target.value });
+          setQuery(prevStatus => {
+            console.log({ v2: e.target.value });
+            return { ...prevStatus, v2: e.target.value };
+          });
+        }}
+        allowClear
+      />
+    </>
+  );
+};
+
+ReactDOM.render(<MyComp />, mountNode);
 ```


### PR DESCRIPTION
#### antd-input
- [issue link](https://github.com/ant-design/ant-design/issues/31927)
- [issue fixed](https://github.com/ant-design/ant-design/pull/31931)

#### 请求帮助🤔
***复现步骤***
1. 安装启动服务
  ```bash
  $ git clone https://github.com/jeffrey-fu/ant-design.git
  $ git check out doubt-input-clear
  $ npm i
  $ npm start
  ```
2. [测试demo链接](http://localhost:8001/components/input-cn/)

***问题描述***
1. 随意输入字符，input失去焦点后，点击清除图标正常清除，console打印
```js
{change: ""}
{v2: ""}
xx
```
2. 随意输入字符，input不失去焦点(重点)，点击清除图标清除异常，console打印
```js
{change: ""}
xx
{v2: "xx"}
```
***自我分析***
```js
const MyComp = () => {
  const [query, setQuery] = useState({ v1: '', v2: '' });

  return (
    <>
      <Input
        value={query.v2}
        onChange={e => {
          console.log({ change: e.target.value });
          setQuery(prevStatus => {
            console.log({ v2: e.target.value });
            return { ...prevStatus, v2: e.target.value };
          });
        }}
        allowClear
      />
    </>
  );
};
/*
setQuery传入函数时会出现问题，应该跟react异步更新有关，刚好传入的参数e又是引用传递
最大的疑惑还是当input失去焦点后又正常了？🤔🤔🤔🤔🤔
作者本身的写法确实不够严谨
*/
onChange(event as React.ChangeEvent<E>);
// reset target ref value
target.value = originalInputValue;
```